### PR TITLE
removing usage of unrest.views.index

### DIFF
--- a/server/main/urls.py
+++ b/server/main/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     path("api/auth/logout/", logout_ajax),
     path("api/registration/complete/<str:activation_key>/", complete_registration),
     path("api/metabase/", metabase_embed),
-    re_path("", include("unrest.schema.urls")),
+    re_path("", include("unrest_schema.urls")),
 ]

--- a/server/main/urls.py
+++ b/server/main/urls.py
@@ -1,13 +1,10 @@
 from django.contrib import admin
 from django.urls import path, re_path, include
-from unrest.views import index
+from main.views import index
 
 from agency.views import metabase_embed
 from user.views import user_json, logout_ajax, complete_registration
 import metabase.forms  # noqa
-
-
-# import unrest.user.forms
 
 urlpatterns = [
     path("admin/", admin.site.urls),

--- a/server/main/views.py
+++ b/server/main/views.py
@@ -1,0 +1,13 @@
+from django.contrib.staticfiles import finders
+from django.views.decorators.csrf import ensure_csrf_cookie
+from django.views.static import serve
+import os
+
+@ensure_csrf_cookie
+def index(request, *args, **kwargs):
+    path = finders.find('index.html')
+    return serve(
+        request,
+        os.path.basename(path),
+        os.path.dirname(path)
+    )

--- a/server/metabase/forms.py
+++ b/server/metabase/forms.py
@@ -1,10 +1,10 @@
 from django import forms
-from unrest import schema
+import unrest_schema
 
 from metabase.models import Dashboard
 
 
-@schema.register
+@unrest_schema.register
 class DashboardForm(forms.ModelForm):
     user_can_LIST = "ALL"
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,6 +2,7 @@ Django==4.0.4
 django-mailer==2.2
 django-registration==3.2
 django-ulid==0.0.4
-django-unrest==0.1.6
+django-unrest-schema==0.0.1
 psycopg2==2.9.3
+PyJWT==2.4.0
 python-dotenv==0.20.0

--- a/server/user/forms.py
+++ b/server/user/forms.py
@@ -10,7 +10,7 @@ from django_registration.backends.activation.views import RegistrationView
 
 from agency.models import Agency, AgencyUser
 from .models import User
-from unrest import schema
+import unrest_schema
 
 
 class UserCreationForm(forms.ModelForm):
@@ -66,7 +66,7 @@ class UserChangeForm(UserChangeForm):
         fields = ("email", "agencies")
 
 
-@schema.register
+@unrest_schema.register
 class LoginForm(forms.Form):
     user_can_POST = "ALL"
     email = forms.CharField(label="Email", max_length=150)
@@ -93,7 +93,7 @@ class LoginForm(forms.Form):
         login(self.request, self.user, backend=backend)
 
 
-@schema.register
+@unrest_schema.register
 class PasswordResetForm(PasswordResetForm):
     user_can_POST = "ALL"
 
@@ -104,7 +104,7 @@ class PasswordResetForm(PasswordResetForm):
         return super().save(*args, **kwargs)
 
 
-@schema.register
+@unrest_schema.register
 class FirstPasswordForm(forms.ModelForm):
     user_can_GET = "SELF"
     user_can_PUT = "SELF"
@@ -168,7 +168,7 @@ def get_reset_user(uidb64, token):
         return user
 
 
-@schema.register
+@unrest_schema.register
 class ResetSetPasswordForm(SetPasswordForm):
     user_can_POST = "ALL"
 


### PR DESCRIPTION
@themightychris pointed out that my kitchen sink repo (django -unrest) had some undesired side effects. 

## Changes

* I moved the index view into a separate file.

* I moved the schema app into a separate repo https://github.com/chriscauley/django-unrest-schema

## Testing Instructions

The codebase should function identically as before, since the code should be the same (minus the [unnecessary "shelling out"](https://github.com/chriscauley/django-unrest/blob/master/unrest/views.py#L20) which prompted this change). Simply deleting the docker container and verifying that you can sign in should be enough.